### PR TITLE
JANAF updates

### DIFF
--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -69,8 +69,6 @@ class JanafPhase(object):
     ValueError: A value in x_new is above the interpolation range.
     """
 
-    # TODO On these docstrings, they actually print array([89,90,18]) rather than [89,90,18].  Is this going to throw off CI?
-
     def __init__(self, rawdata_text):
         # Store the raw data text file from NIST.
         self.rawdata_text = rawdata_text
@@ -86,12 +84,10 @@ class JanafPhase(object):
             engine='python',
             names=['T', 'Cp', 'S', '[G-H(Tr)]/T', 'H-H(Tr)', 'Delta_fH', 'Delta_fG', 'log(Kf)']
         )
-        # data.columns = ['T', 'Cp', 'S', '[G-H(Tr)]/T', 'H-H(Tr)', 'Delta_fH',
-                        # 'Delta_fG', 'log(Kf)']
         self.rawdata = data
 
-        # Sometimes the JANAF files have funky stuff written in them. (Old
-        # school text format...)
+        # Sometimes the JANAF files have funky stuff written in them.
+        # (Old school text format...)
         # Clean it up.
         for c in data.columns:
             # We only need to polish up columns that aren't floating point
@@ -108,7 +104,8 @@ class JanafPhase(object):
         data['Delta_fH'] *= 1000
         data['Delta_fG'] *= 1000
 
-        # Handle NaNs for the phase transition points.  This only affects Delta_fG, Delta_fH, and log(Kf)
+        # Handle NaNs for the phase transition points. This only affects
+        # Delta_fG, Delta_fH, and log(Kf)
         good_indices = np.where(np.isfinite(data['Delta_fH']))
 
         # Now make interpolatable functions for each of these.

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -120,9 +120,6 @@ class JanafPhase(object):
         self.logKf = interp1d(self.rawdata['T'].iloc[good_indices],
                               self.rawdata['log(Kf)'].iloc[good_indices])
 
-        # TODO Deal well with crystal<->liquid transitions which have a below
-        # and above value for Cp, S, etc.
-
     def __str__(self):
         rep = super().__str__()
         rep += "\n  "

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -109,17 +109,20 @@ class JanafPhase(object):
         data['Delta_fG'] *= 1000
 
         # Handle NaNs for the phase transition points.  This only affects Delta_fG, Delta_fH, and log(Kf)
-        GoodIndices = np.where(np.isfinite(data['Delta_fH']))
-        print(GoodIndices)
+        good_indices = np.where(np.isfinite(data['Delta_fH']))
+        print(good_indices)
 
         # Now make interpolatable functions for each of these.
         self.cp = interp1d(self.rawdata['T'], self.rawdata['Cp'])
         self.S = interp1d(self.rawdata['T'], self.rawdata['S'])
         self.gef = interp1d(self.rawdata['T'], self.rawdata['[G-H(Tr)]/T'])
         self.hef = interp1d(self.rawdata['T'], self.rawdata['H-H(Tr)'])
-        self.DeltaH = interp1d(self.rawdata['T'].iloc[GoodIndices], self.rawdata['Delta_fH'].iloc[GoodIndices])
-        self.DeltaG = interp1d(self.rawdata['T'].iloc[GoodIndices], self.rawdata['Delta_fG'].iloc[GoodIndices])
-        self.logKf = interp1d(self.rawdata['T'].iloc[GoodIndices], self.rawdata['log(Kf)'].iloc[GoodIndices])
+        self.DeltaH = interp1d(self.rawdata['T'].iloc[good_indices],
+                               self.rawdata['Delta_fH'].iloc[good_indices])
+        self.DeltaG = interp1d(self.rawdata['T'].iloc[good_indices],
+                               self.rawdata['Delta_fG'].iloc[good_indices])
+        self.logKf = interp1d(self.rawdata['T'].iloc[good_indices],
+                              self.rawdata['log(Kf)'].iloc[good_indices])
 
         # TODO Deal well with crystal<->liquid transitions which have a below
         # and above value for Cp, S, etc.

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -110,7 +110,6 @@ class JanafPhase(object):
 
         # Handle NaNs for the phase transition points.  This only affects Delta_fG, Delta_fH, and log(Kf)
         good_indices = np.where(np.isfinite(data['Delta_fH']))
-        print(good_indices)
 
         # Now make interpolatable functions for each of these.
         self.cp = interp1d(self.rawdata['T'], self.rawdata['Cp'])

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -152,7 +152,7 @@ class Janafdb(object):
         to load thermodynamic constants for TiO2, rutile.
     """
     VALIDPHASETYPES = ['cr', 'l', 'cr,l', 'g', 'ref', 'cd', 'fl', 'am', 'vit',
-                       'mon', 'pol', 'sln', 'aq', 'sat', None]
+                       'mon', 'pol', 'sln', 'aq', 'sat']
     JANAF_URL = "https://janaf.nist.gov/tables/%s.txt"
 
     def __init__(self):
@@ -232,7 +232,7 @@ class Janafdb(object):
         # Check that the phase type requested is valid.
         if phase is not None:
             phase = phase.lower()
-        if phase not in self.VALIDPHASETYPES:
+        if phase is not None and phase not in self.VALIDPHASETYPES:
             raise ValueError("Valid phase types are %s." % self.VALIDPHASETYPES)
 
         # We can search on either an exact formula, partial text match in the

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -227,6 +227,17 @@ class Janafdb(object):
             ...
         ValueError: Did not find a phase with formula = Oxyz, phase = l
                     Please provide enough information to select a unique record.
+        >>> FeO = db.getphasedata(formula='FeO', phase='cr,l')
+        >>> print(FeO)
+        <thermochem.janaf.JanafPhase object at 0x...>
+          Iron Oxide (FeO)  Fe1O1(cr,l)
+            Cp(298.15) = 49.915 J/mol/K
+            S(298.15) = 60.752 J/mol/K
+            [G-H(298.15)]/298.15 = 60.752 J/mol/K
+            H-H(298.15) = 0.000 J/mol/K
+            Delta_fH(298.15) = -272044 J/mol
+            Delta_fG(298.15) = -251429 J/mol
+            log(Kf((298.15)) = 44.049
         """
 
         # Check that the phase type requested is valid.

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -249,7 +249,7 @@ class Janafdb(object):
             # Select records that match the chemical/mineral name.
             namesearch = self.db['name'].str.lower().str.contains(name.lower())
         if phase is not None:
-            phasesearch = self.db['phase'] == phase.lower()
+            phasesearch = self.db['phase'] == phase
         if filename is not None:
             # Select only records that match the filename on the website (this is very unique.)
             filenamesearch = self.db['filename'].str.lower() == filename.lower()

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -108,14 +108,18 @@ class JanafPhase(object):
         data['Delta_fH'] *= 1000
         data['Delta_fG'] *= 1000
 
+        # Handle NaNs for the phase transition points.  This only affects Delta_fG, Delta_fH, and log(Kf)
+        GoodIndices = np.where(np.isfinite(data['Delta_fH']))
+        print(GoodIndices)
+
         # Now make interpolatable functions for each of these.
         self.cp = interp1d(self.rawdata['T'], self.rawdata['Cp'])
         self.S = interp1d(self.rawdata['T'], self.rawdata['S'])
         self.gef = interp1d(self.rawdata['T'], self.rawdata['[G-H(Tr)]/T'])
         self.hef = interp1d(self.rawdata['T'], self.rawdata['H-H(Tr)'])
-        self.DeltaH = interp1d(self.rawdata['T'], self.rawdata['Delta_fH'])
-        self.DeltaG = interp1d(self.rawdata['T'], self.rawdata['Delta_fG'])
-        self.logKf = interp1d(self.rawdata['T'], self.rawdata['log(Kf)'])
+        self.DeltaH = interp1d(self.rawdata['T'].iloc[GoodIndices], self.rawdata['Delta_fH'].iloc[GoodIndices])
+        self.DeltaG = interp1d(self.rawdata['T'].iloc[GoodIndices], self.rawdata['Delta_fG'].iloc[GoodIndices])
+        self.logKf = interp1d(self.rawdata['T'].iloc[GoodIndices], self.rawdata['log(Kf)'].iloc[GoodIndices])
 
         # TODO Deal well with crystal<->liquid transitions which have a below
         # and above value for Cp, S, etc.

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -121,16 +121,16 @@ class JanafPhase(object):
                               self.rawdata['log(Kf)'].iloc[good_indices])
 
     def __str__(self):
-        rep = super().__str__()
+        rep = super(JanafPhase, self).__str__()
         rep += "\n  "
         rep += self.description
-        rep += "\n    Cp(%0.2f) = %0.3f J/mol/K"%(Tr, self.cp(Tr))
-        rep += "\n    S(%0.2f) = %0.3f J/mol/K"%(Tr, self.S(Tr))
-        rep += "\n    [G-H(%0.2f)]/%0.2f = %0.3f J/mol/K"%(Tr, Tr, self.gef(Tr))
-        rep += "\n    H-H(%0.2f) = %0.3f J/mol/K"%(Tr, self.hef(Tr))
-        rep += "\n    Delta_fH(%0.2f) = %0.0f J/mol"%(Tr, self.DeltaH(Tr))
-        rep += "\n    Delta_fG(%0.2f) = %0.0f J/mol"%(Tr, self.DeltaG(Tr))
-        rep += "\n    log(Kf((%0.2f)) = %0.3f"%(Tr, self.logKf(Tr))
+        rep += "\n    Cp(%0.2f) = %0.3f J/mol/K" % (Tr, self.cp(Tr))
+        rep += "\n    S(%0.2f) = %0.3f J/mol/K" % (Tr, self.S(Tr))
+        rep += "\n    [G-H(%0.2f)]/%0.2f = %0.3f J/mol/K" % (Tr, Tr, self.gef(Tr))
+        rep += "\n    H-H(%0.2f) = %0.3f J/mol/K" % (Tr, self.hef(Tr))
+        rep += "\n    Delta_fH(%0.2f) = %0.0f J/mol" % (Tr, self.DeltaH(Tr))
+        rep += "\n    Delta_fG(%0.2f) = %0.0f J/mol" % (Tr, self.DeltaG(Tr))
+        rep += "\n    log(Kf((%0.2f)) = %0.3f" % (Tr, self.logKf(Tr))
         return rep
 
 


### PR DESCRIPTION
I fixed some bugs where it wasn't successfully reading some phases due to formatting issues in the source JANAF files.

I also made some usability improvements: namely print(phase) doesn't just print the name of the class but also prints STP thermodynamic values and the name of the phase.

One thing I'm not sure about is the format for the docstrings.  For example, one of them is:

    >>> print(p.S([500, 550, 1800]))        # Entropy in J/mol/K
    [  82.201    88.4565  176.876 ]
 
but the actual return value from python is

np.array([  82.201    88.4565  176.876 ])

I'm not sure if the testing module is smart enough to see through that or if I should modify the docstrings.