### PR TITLE
Raise ParserWarning not ParserError for Pandas > 1.3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ automatically with any of the installation instructions provided.
 
 -  SciPy >= 0.6.0
 
--  pandas >= 0.17.0
+-  pandas >= 1.3.0
 
 Development
 -----------

--- a/thermochem/janaf.py
+++ b/thermochem/janaf.py
@@ -77,7 +77,6 @@ class JanafPhase(object):
         self.description = self.rawdata_text.splitlines()[0]
 
         # Read the text file into a DataFrame.
-        # TODO: adjust usecols length to be within bounds, Pandas deprecation
         data = pd.read_csv(
             StringIO(self.rawdata_text),
             skiprows=2,
@@ -85,7 +84,7 @@ class JanafPhase(object):
             delimiter=r'[\t\s]+',
             engine='python',
             names=['T', 'Cp', 'S', '[G-H(Tr)]/T', 'H-H(Tr)', 'Delta_fH', 'Delta_fG', 'log(Kf)'],
-            usecols=range(8) # Ignore extra columns -- those are caused by comments in the text file
+            on_bad_lines='warn'
         )
         self.rawdata = data
 


### PR DESCRIPTION
Raise a ParserWarning to avoid the ParserError `pandas.errors.ParserError: Defining usecols with out-of-bounds indices is not allowed.` when using Pandas>1.3.5.  Now a warning is output for the problematic lines (which relate to comments in the JANAF data).

Tested on an example txt file: https://janaf.nist.gov/tables/H-066.txt